### PR TITLE
completed carousel component with second preview, fixed formating

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,23 +3,23 @@
     "version": "0.1.0",
     "private": true,
     "scripts": {
-          "dev": "next dev",
-          "build": "next build",
-          "start": "next start",
-          "lint": "next lint"
+        "dev": "next dev",
+        "build": "next build",
+        "start": "next start",
+        "lint": "next lint"
     },
     "dependencies": {
-          "@headlessui/react": "^2.1.2",
-          "@heroicons/react": "^2.1.5",
-          "next": "^14.2.5",
-          "react": "^18.3.1",
-          "react-dom": "^18",
+        "@headlessui/react": "^2.1.2",
+        "@heroicons/react": "^2.1.5",
+        "next": "^14.2.5",
+        "react": "^18.3.1",
+        "react-dom": "^18",
         "react-syntax-highlighter": "^15.5.0"
     },
     "devDependencies": {
-          "postcss": "^8",
-          "prettier": "^3.3.3",
-          "prettier-plugin-tailwindcss": "^0.6.5",
-          "tailwindcss": "^3.2.0"
+        "postcss": "^8",
+        "prettier": "^3.3.3",
+        "prettier-plugin-tailwindcss": "^0.6.5",
+        "tailwindcss": "^3.2.0"
     }
 }

--- a/src/app/components/Carousel/CarouselList.js
+++ b/src/app/components/Carousel/CarouselList.js
@@ -2,6 +2,8 @@ import { useState } from "react";
 
 import carouselOne from "./carouselOne";
 import carouselOneCode from "./snippets/carouselOneCode";
+import carouselTwo from "./carouselTwo";
+import carouselTwoCode from "./snippets/carouselTwoCode";
 
 export default function CarouselList() {
   const carousels = [
@@ -9,9 +11,11 @@ export default function CarouselList() {
       id: 1,
       component: carouselOne,
       code: carouselOneCode,
-      props: {
-        backgroundColor: "bg-[#FFF8F0]",
-      },
+    },
+    {
+      id: 2,
+      component: carouselTwo,
+      code: carouselTwoCode,
     },
   ];
 
@@ -42,7 +46,7 @@ export default function CarouselList() {
               </button>
             </div>
             <div
-              className={`w-full h-96 overflow-y-scroll ${previewStates[index] ? "bg-[#523B82]" : "bg-[#1e293b]"}`}
+              className={`w-full h-96 overflow-auto ${previewStates[index] ? "" : "bg-[#1e293b]"}`}
             >
               {previewStates[index] ? (
                 <CarouselComponent {...carousel.props} />

--- a/src/app/components/Carousel/carouselTwo.js
+++ b/src/app/components/Carousel/carouselTwo.js
@@ -3,7 +3,7 @@
 import React, { Component } from "react";
 import Image from "next/image"; // Import Next.js Image component
 
-export default class CarouselOne extends Component {
+export default class CarouselTwo extends Component {
   constructor(props) {
     super(props);
     this.state = {
@@ -16,16 +16,6 @@ export default class CarouselOne extends Component {
     { src: "/images/bvt_logo.png", alt: "Logo Image" },
     { src: "/images/ui-shop-tool-kit.png", alt: "Second Image" },
   ];
-
-  componentDidMount() {
-    // Automatically go to the next slide every 3 seconds (3000 ms)
-    this.interval = setInterval(this.goToNext, 3000);
-  }
-
-  componentWillUnmount() {
-    // Clear interval when the component is unmounted to prevent memory leaks
-    clearInterval(this.interval);
-  }
 
   goToNext = () => {
     this.setState((prevState) => ({
@@ -50,7 +40,7 @@ export default class CarouselOne extends Component {
         {/* Carousel wrapper */}
         <div className="overflow-hidden rounded-lg">
           <div
-            className="flex transition-transform duration-700 ease-in-out"
+            className="flex transition-transform duration-200 ease-linear"
             style={{ transform: `translateX(-${currentIndex * 100}%)` }}
           >
             {this.slides.map((slide, index) => (
@@ -75,7 +65,10 @@ export default class CarouselOne extends Component {
           onClick={this.goToPrevious}
           className="absolute top-1/2 left-0 transform -translate-y-1/2 bg-gray-800 bg-opacity-50 text-white p-2 rounded-full hover:bg-opacity-75"
         >
-          &lt;
+          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor" className="size-6">
+            <path strokeLinecap="round" strokeLinejoin="round" d="m18.75 4.5-7.5 7.5 7.5 7.5m-6-15L5.25 12l7.5 7.5" />
+            </svg>
+
         </button>
 
         {/* Next Button */}
@@ -83,7 +76,10 @@ export default class CarouselOne extends Component {
           onClick={this.goToNext}
           className="absolute top-1/2 right-0 transform -translate-y-1/2 bg-gray-800 bg-opacity-50 text-white p-2 rounded-full hover:bg-opacity-75"
         >
-          &gt;
+            <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor" className="size-6">
+                <path strokeLinecap="round" strokeLinejoin="round" d="m5.25 4.5 7.5 7.5-7.5 7.5m6-15 7.5 7.5-7.5 7.5" />
+            </svg>
+
         </button>
 
         {/* Indicators */}
@@ -92,8 +88,8 @@ export default class CarouselOne extends Component {
             <button
               key={index}
               onClick={() => this.setState({ currentIndex: index })}
-              className={`w-3 h-3 mx-1 rounded-full ${
-                currentIndex === index ? "bg-blue-500" : "bg-gray-300"
+              className={`w-3 h-3 mx-1 ${
+                currentIndex === index ? "bg-green-500" : "bg-white"
               }`}
             />
           ))}

--- a/src/app/components/Carousel/snippets/carouselTwoCode.js
+++ b/src/app/components/Carousel/snippets/carouselTwoCode.js
@@ -1,9 +1,10 @@
-"use client";
+const carouselTwoCode = `
+  "use client";
 
 import React, { Component } from "react";
 import Image from "next/image"; // Import Next.js Image component
 
-export default class CarouselOne extends Component {
+export default class CarouselTwo extends Component {
   constructor(props) {
     super(props);
     this.state = {
@@ -16,16 +17,6 @@ export default class CarouselOne extends Component {
     { src: "/images/bvt_logo.png", alt: "Logo Image" },
     { src: "/images/ui-shop-tool-kit.png", alt: "Second Image" },
   ];
-
-  componentDidMount() {
-    // Automatically go to the next slide every 3 seconds (3000 ms)
-    this.interval = setInterval(this.goToNext, 3000);
-  }
-
-  componentWillUnmount() {
-    // Clear interval when the component is unmounted to prevent memory leaks
-    clearInterval(this.interval);
-  }
 
   goToNext = () => {
     this.setState((prevState) => ({
@@ -50,8 +41,8 @@ export default class CarouselOne extends Component {
         {/* Carousel wrapper */}
         <div className="overflow-hidden rounded-lg">
           <div
-            className="flex transition-transform duration-700 ease-in-out"
-            style={{ transform: `translateX(-${currentIndex * 100}%)` }}
+            className="flex transition-transform duration-200 ease-linear"
+            style={{ transform: \`translateX(-\${currentIndex * 100}%)\` }}
           >
             {this.slides.map((slide, index) => (
               <div
@@ -75,7 +66,10 @@ export default class CarouselOne extends Component {
           onClick={this.goToPrevious}
           className="absolute top-1/2 left-0 transform -translate-y-1/2 bg-gray-800 bg-opacity-50 text-white p-2 rounded-full hover:bg-opacity-75"
         >
-          &lt;
+          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor" className="size-6">
+            <path strokeLinecap="round" strokeLinejoin="round" d="m18.75 4.5-7.5 7.5 7.5 7.5m-6-15L5.25 12l7.5 7.5" />
+            </svg>
+
         </button>
 
         {/* Next Button */}
@@ -83,7 +77,10 @@ export default class CarouselOne extends Component {
           onClick={this.goToNext}
           className="absolute top-1/2 right-0 transform -translate-y-1/2 bg-gray-800 bg-opacity-50 text-white p-2 rounded-full hover:bg-opacity-75"
         >
-          &gt;
+            <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor" className="size-6">
+                <path strokeLinecap="round" strokeLinejoin="round" d="m5.25 4.5 7.5 7.5-7.5 7.5m6-15 7.5 7.5-7.5 7.5" />
+            </svg>
+
         </button>
 
         {/* Indicators */}
@@ -92,9 +89,9 @@ export default class CarouselOne extends Component {
             <button
               key={index}
               onClick={() => this.setState({ currentIndex: index })}
-              className={`w-3 h-3 mx-1 rounded-full ${
-                currentIndex === index ? "bg-blue-500" : "bg-gray-300"
-              }`}
+              className={\`w-3 h-3 mx-1 \${
+                currentIndex === index ? "bg-green-500" : "bg-white"
+              }\`}
             />
           ))}
         </div>
@@ -102,3 +99,8 @@ export default class CarouselOne extends Component {
     );
   }
 }
+
+
+`;
+
+export default carouselTwoCode;


### PR DESCRIPTION
## Images
![image](https://github.com/user-attachments/assets/14025f2c-05b8-4e28-bc99-fb57ccac142e)
![image](https://github.com/user-attachments/assets/6425048e-9311-4eab-9519-0de093c586af)
![image](https://github.com/user-attachments/assets/99f38663-1d21-45a4-8c4e-b68d1705ffbc)


## Changes
Fixed formatting on carousel components
added a second carousel with different indicators and animation speed

_Links to blog posts, patterns, libraries or addons used to solve this problem_
https://flowbite.com/docs/components/carousel/
https://heroicons.com
Chat GPT

_If this closes an issue, reference the issue here. If it doesn't, remove this line_
Closes #17 
